### PR TITLE
Update euclid.cfg

### DIFF
--- a/euclid.cfg
+++ b/euclid.cfg
@@ -80,8 +80,11 @@ gcode:
   PAM
   QUERY_PROBE
   M402          ; dock probe
-  {% endif %}
+  {% else %}
+  QUERY_PROBE
+  M402  
   BED_MESH_PROFILE LOAD=ratos
+  {% endif %}
 
 [gcode_macro _START_PRINT_AFTER_HEATING_BED]
 gcode:


### PR DESCRIPTION
update _START_PRINT_BED_MESH - if statement finishes and then always loads the saved ratos profile even if you are currently doing a mesh.  chagned to load current mesh when appropriate.